### PR TITLE
Fix most broken quest rewards

### DIFF
--- a/minecraft/config/ftbquests/quests/chapters/create.snbt
+++ b/minecraft/config/ftbquests/quests/chapters/create.snbt
@@ -3,11 +3,23 @@
 	default_quest_shape: ""
 	filename: "create"
 	group: ""
+	icon: {
+		components: {
+			"ftbquests:icon": "create:textures/gui/logo.png"
+		}
+		id: "ftbquests:custom_icon"
+	}
 	id: "0000000000000623"
 	order_index: 2
 	quest_links: [ ]
 	quests: [
 		{
+			icon: {
+				components: {
+					"ftbquests:icon": "create:textures/gui/logo.png"
+				}
+				id: "ftbquests:custom_icon"
+			}
 			id: "000000000000062C"
 			rewards: [{
 				count: 8
@@ -142,6 +154,7 @@
 				}
 				type: "item"
 			}]
+			shape: "octagon"
 			tasks: [{
 				count: 4L
 				id: "000000000000079A"
@@ -428,8 +441,8 @@
 				item: { count: 1, id: "create:millstone" }
 				type: "item"
 			}]
-			x: -1.0d
-			y: 2.0d
+			x: -1.5d
+			y: 3.5d
 		}
 		{
 			dependencies: ["00000000000007A3"]
@@ -536,8 +549,8 @@
 				item: { count: 1, id: "create:spout" }
 				type: "item"
 			}]
-			x: 8.5d
-			y: 10.5d
+			x: 8.0d
+			y: 10.0d
 		}
 		{
 			dependencies: ["00000000000007A1"]
@@ -587,7 +600,7 @@
 				type: "item"
 			}]
 			x: 1.0d
-			y: 6.0d
+			y: 5.5d
 		}
 		{
 			dependencies: ["00000000000007BD"]
@@ -686,8 +699,8 @@
 				item: { count: 1, id: "create:mechanical_bearing" }
 				type: "item"
 			}]
-			x: 1.5d
-			y: 4.0d
+			x: 1.0d
+			y: 3.5d
 		}
 		{
 			dependencies: ["000000000000078F"]
@@ -974,7 +987,7 @@
 				type: "item"
 			}]
 			x: -1.5d
-			y: 5.0d
+			y: 4.5d
 		}
 		{
 			dependencies: ["00000000000007A1"]
@@ -1009,6 +1022,13 @@
 			rewards: [{
 				id: "3073DBD47D347721"
 				item: {
+					components: {
+						"minecraft:stored_enchantments": {
+							levels: {
+								"minecraft:unbreaking": 3
+							}
+						}
+					}
 					count: 1
 					id: "minecraft:enchanted_book"
 				}
@@ -1060,7 +1080,7 @@
 				item: { count: 1, id: "create:blaze_burner" }
 				type: "item"
 			}]
-			x: -8.5d
+			x: -9.0d
 			y: 7.0d
 		}
 		{
@@ -1079,7 +1099,7 @@
 				item: { count: 1, id: "create:blaze_cake_base" }
 				type: "item"
 			}]
-			x: -8.5d
+			x: -9.0d
 			y: 5.5d
 		}
 		{
@@ -1099,7 +1119,7 @@
 				item: { count: 1, id: "create:blaze_cake" }
 				type: "item"
 			}]
-			x: -8.5d
+			x: -9.0d
 			y: 4.0d
 		}
 		{
@@ -1177,8 +1197,8 @@
 				item: { count: 1, id: "create:andesite_tunnel" }
 				type: "item"
 			}]
-			x: -1.5d
-			y: 4.0d
+			x: -1.0d
+			y: 5.5d
 		}
 		{
 			dependencies: ["00000000000008D1"]
@@ -1187,6 +1207,13 @@
 				{
 					id: "462C861464D608FA"
 					item: {
+						components: {
+							"minecraft:stored_enchantments": {
+								levels: {
+									"minecraft:sharpness": 5
+								}
+							}
+						}
 						count: 1
 						id: "minecraft:enchanted_book"
 					}
@@ -1217,7 +1244,7 @@
 				id: "3EFDD0FFE080BE6C"
 				item: {
 					count: 1
-					id: "create:red_sand_paper"
+					id: "createaddition:diamond_grit_sandpaper"
 				}
 				type: "item"
 			}]
@@ -1448,6 +1475,13 @@
 			rewards: [{
 				id: "35502B756B837E0E"
 				item: {
+					components: {
+						"minecraft:stored_enchantments": {
+							levels: {
+								"minecraft:mending": 1
+							}
+						}
+					}
 					count: 1
 					id: "minecraft:enchanted_book"
 				}
@@ -1577,44 +1611,6 @@
 			rewards: [{
 				id: "2CF057ECD70E61E3"
 				item: {
-					count: 1
-					id: "minecraft:enchanted_book"
-				}
-				type: "item"
-			}]
-			tasks: [{
-				id: "5B848E32F14497FA"
-				item: { count: 1, id: "create_sa:brass_jetpack_chestplate" }
-				type: "item"
-			}]
-			x: 5.0d
-			y: 14.5d
-		}
-		{
-			dependencies: ["00000000000008D1"]
-			id: "7DC3C9C543BFAE8E"
-			rewards: [{
-				id: "022B6D3DC955AE29"
-				item: {
-					count: 1
-					id: "minecraft:enchanted_book"
-				}
-				type: "item"
-			}]
-			tasks: [{
-				id: "0743AEE69F601F0B"
-				item: { count: 1, id: "create_sa:andesite_jetpack_chestplate" }
-				type: "item"
-			}]
-			x: 6.0d
-			y: 14.0d
-		}
-		{
-			dependencies: ["00000000000007C7"]
-			id: "285AF2D75FD9809C"
-			rewards: [{
-				id: "06010E87AB020FE9"
-				item: {
 					components: {
 						"minecraft:stored_enchantments": {
 							levels: {
@@ -1628,12 +1624,64 @@
 				type: "item"
 			}]
 			tasks: [{
+				id: "5B848E32F14497FA"
+				item: { count: 1, id: "create_sa:brass_jetpack_chestplate" }
+				type: "item"
+			}]
+			x: 8.0d
+			y: 14.5d
+		}
+		{
+			dependencies: ["00000000000008D1"]
+			id: "7DC3C9C543BFAE8E"
+			rewards: [{
+				id: "022B6D3DC955AE29"
+				item: {
+					components: {
+						"minecraft:stored_enchantments": {
+							levels: {
+								"create:capacity": 1
+							}
+						}
+					}
+					count: 1
+					id: "minecraft:enchanted_book"
+				}
+				type: "item"
+			}]
+			tasks: [{
+				id: "0743AEE69F601F0B"
+				item: { count: 1, id: "create_sa:andesite_jetpack_chestplate" }
+				type: "item"
+			}]
+			x: 8.0d
+			y: 13.0d
+		}
+		{
+			dependencies: ["00000000000007C7"]
+			id: "285AF2D75FD9809C"
+			rewards: [{
+				id: "06010E87AB020FE9"
+				item: {
+					components: {
+						"minecraft:stored_enchantments": {
+							levels: {
+								"create:capacity": 1
+							}
+						}
+					}
+					count: 1
+					id: "minecraft:enchanted_book"
+				}
+				type: "item"
+			}]
+			tasks: [{
 				id: "571AB8723B5BA2B7"
 				item: { count: 1, id: "create_sa:copper_jetpack_chestplate" }
 				type: "item"
 			}]
-			x: 8.5d
-			y: 12.5d
+			x: 8.0d
+			y: 11.5d
 		}
 		{
 			dependencies: ["0000000000000799"]
@@ -1653,8 +1701,8 @@
 				item: { count: 1, id: "create_mechanical_extruder:mechanical_extruder" }
 				type: "item"
 			}]
-			x: -2.0d
-			y: 2.0d
+			x: -1.0d
+			y: 2.5d
 		}
 		{
 			dependencies: ["03108B7D1A7458B3"]
@@ -1852,8 +1900,8 @@
 				item: { count: 1, id: "create:sticky_mechanical_piston" }
 				type: "item"
 			}]
-			x: -1.0d
-			y: 6.0d
+			x: 1.5d
+			y: 4.5d
 		}
 		{
 			dependencies: ["51FE487A5586AF80"]
@@ -2231,6 +2279,7 @@
 			y: -5.5d
 		}
 		{
+			dependencies: ["5AF43A02E87E4DF8"]
 			id: "3D66EBF3A215F354"
 			rewards: [{
 				id: "737DF23F3AA20171"
@@ -2245,7 +2294,7 @@
 				item: { count: 1, id: "create_enchantment_industry:blaze_enchanter" }
 				type: "item"
 			}]
-			x: -9.5d
+			x: -9.0d
 			y: 8.5d
 		}
 		{
@@ -2272,10 +2321,10 @@
 			id: "485280315689B86E"
 			tasks: [{
 				id: "6583BC3A0245CAE3"
-				item: { count: 1, id: "createaddition:biomass_pellet" }
+				item: { count: 1, id: "createaddition:biomass" }
 				type: "item"
 			}]
-			x: -10.0d
+			x: -12.0d
 			y: 7.0d
 		}
 		{
@@ -2283,14 +2332,14 @@
 			id: "1AB29695173FFFA1"
 			tasks: [{
 				id: "58EF8F6CD11FD754"
-				item: { components: { "ftbquests:missing_item": "createaddition:biomass_pellet" }, count: 1, id: "ftbquests:missing_item" }
+				item: { count: 1, id: "createaddition:biomass_pellet" }
 				type: "item"
 			}]
-			x: -11.5d
-			y: 8.0d
+			x: -13.5d
+			y: 7.0d
 		}
 		{
-			dependencies: ["485280315689B86E"]
+			dependencies: ["5AF43A02E87E4DF8"]
 			id: "22DC6FB53C9268C6"
 			rewards: [{
 				count: 32
@@ -2306,8 +2355,8 @@
 				item: { count: 1, id: "createaddition:bioethanol_bucket" }
 				type: "item"
 			}]
-			x: -11.5d
-			y: 6.0d
+			x: -10.5d
+			y: 7.0d
 		}
 	]
 }

--- a/minecraft/config/ftbquests/quests/chapters/farmer.snbt
+++ b/minecraft/config/ftbquests/quests/chapters/farmer.snbt
@@ -134,11 +134,8 @@
 			rewards: [{
 				id: "5C35101DF8B8054D"
 				item: {
-					components: {
-						"ftbquests:missing_item": "createaddition:seed_oil_bucket"
-					}
 					count: 1
-					id: "ftbquests:missing_item"
+					id: "createaddition:seed_oil_bucket"
 				}
 				type: "item"
 			}]
@@ -611,6 +608,13 @@
 			rewards: [{
 				id: "7A2348631A273A35"
 				item: {
+					components: {
+						"minecraft:stored_enchantments": {
+							levels: {
+								"farmersdelight:backstabbing": 3
+							}
+						}
+					}
 					count: 1
 					id: "minecraft:enchanted_book"
 				}
@@ -630,17 +634,14 @@
 				count: 4
 				id: "48B4E42C5979208F"
 				item: {
-					components: {
-						"ftbquests:missing_item": "refinedstorage:basic_processor"
-					}
 					count: 1
-					id: "ftbquests:missing_item"
+					id: "ae2:logic_processor"
 				}
 				type: "item"
 			}]
 			tasks: [{
 				id: "48F8C7213DDC26FC"
-				item: { components: { "ftbquests:missing_item": "itemfilters:tag" }, count: 1, id: "ftbquests:missing_item" }
+				item: { components: { "ftbfiltersystem:filter": "ftbfiltersystem:item_tag(farmersdelight:cabinets)" }, count: 1, id: "ftbfiltersystem:smart_filter" }
 				type: "item"
 			}]
 			x: 16.0d

--- a/minecraft/config/ftbquests/quests/chapters/fromthedarkness.snbt
+++ b/minecraft/config/ftbquests/quests/chapters/fromthedarkness.snbt
@@ -3,6 +3,9 @@
 	default_quest_shape: ""
 	filename: "fromthedarkness"
 	group: ""
+	icon: {
+		id: "minecraft:baked_potato"
+	}
 	id: "0000000000000004"
 	order_index: 0
 	quest_links: [ ]
@@ -260,7 +263,7 @@
 				type: "item"
 			}]
 			tasks: [{
-				count: 64L
+				count: 16L
 				id: "00000000000000CA"
 				item: { count: 1, id: "minecraft:stone" }
 				type: "item"
@@ -280,7 +283,7 @@
 				type: "item"
 			}]
 			tasks: [{
-				count: 64L
+				count: 16L
 				id: "00000000000000CC"
 				item: { count: 1, id: "minecraft:smooth_stone" }
 				type: "item"
@@ -290,6 +293,12 @@
 		}
 		{
 			dependencies: ["3E046FB9DDB11119"]
+			icon: {
+				components: {
+					"ftbquests:icon": "ftblibrary:icons/map"
+				}
+				id: "ftbquests:custom_icon"
+			}
 			id: "6F94CFF9E4013396"
 			rewards: [{
 				id: "7694CC56CD10814B"
@@ -305,6 +314,12 @@
 		}
 		{
 			dependencies: ["3E046FB9DDB11119"]
+			icon: {
+				components: {
+					"ftbquests:icon": "minecraft:block/command_block_back"
+				}
+				id: "ftbquests:custom_icon"
+			}
 			id: "03F55170BAB80CD2"
 			rewards: [{
 				id: "271EE954A8D05977"
@@ -319,6 +334,12 @@
 			y: 2.0d
 		}
 		{
+			icon: {
+				components: {
+					"ftbquests:icon": "ftblibrary:icons/info"
+				}
+				id: "ftbquests:custom_icon"
+			}
 			id: "3E046FB9DDB11119"
 			rewards: [{
 				id: "1DD1FE2C8C0F4E41"
@@ -336,6 +357,12 @@
 		}
 		{
 			dependencies: ["3E046FB9DDB11119"]
+			icon: {
+				components: {
+					"ftbquests:icon": "minecraft:block/bookshelf"
+				}
+				id: "ftbquests:custom_icon"
+			}
 			id: "5AF39FF6AB1C6098"
 			rewards: [{
 				id: "59D3F3644923777E"
@@ -469,7 +496,7 @@
 				type: "item"
 			}]
 			tasks: [{
-				count: 16L
+				count: 8L
 				id: "06127A83513CBD7C"
 				item: { count: 1, id: "minecraft:iron_ingot" }
 				type: "item"
@@ -528,6 +555,9 @@
 		{
 			can_repeat: true
 			dependencies: ["3E046FB9DDB11119"]
+			icon: {
+				id: "theoneprobe:probenote"
+			}
 			id: "0E4D24AAB4F4DC58"
 			rewards: [{
 				id: "7432D03495AC18F0"

--- a/minecraft/config/ftbquests/quests/chapters/hunter.snbt
+++ b/minecraft/config/ftbquests/quests/chapters/hunter.snbt
@@ -304,10 +304,16 @@
 				id: "000000000000023D"
 				item: {
 					components: {
-						"ftbquests:missing_item": "powder_power:armor_quadrilium_body"
+						"minecraft:enchantments": {
+							levels: {
+								"minecraft:mending": 1
+								"minecraft:protection": 4
+								"minecraft:unbreaking": 4
+							}
+						}
 					}
 					count: 1
-					id: "ftbquests:missing_item"
+					id: "powder_power:armor_quadrilium_chestplate"
 				}
 				type: "item"
 			}]
@@ -728,10 +734,16 @@
 				id: "3470EA5C011CE0BC"
 				item: {
 					components: {
-						"ftbquests:missing_item": "powder_power:armor_quadrilium_head"
+						"minecraft:enchantments": {
+							levels: {
+								"minecraft:blast_protection": 4
+								"minecraft:mending": 1
+								"minecraft:unbreaking": 4
+							}
+						}
 					}
 					count: 1
-					id: "ftbquests:missing_item"
+					id: "powder_power:armor_quadrilium_helmet"
 				}
 				type: "item"
 			}]

--- a/minecraft/config/ftbquests/quests/chapters/hunter.snbt
+++ b/minecraft/config/ftbquests/quests/chapters/hunter.snbt
@@ -57,6 +57,17 @@
 			rewards: [{
 				id: "0000000000000047"
 				item: {
+					components: {
+						"minecraft:enchantments": {
+							levels: {
+								"minecraft:flame": 1
+								"minecraft:infinity": 1
+								"minecraft:power": 6
+								"minecraft:punch": 2
+								"minecraft:unbreaking": 3
+							}
+						}
+					}
 					count: 1
 					id: "powder_power:bow_quadrilium"
 				}
@@ -97,6 +108,13 @@
 			rewards: [{
 				id: "0000000000000054"
 				item: {
+					components: {
+						"minecraft:stored_enchantments": {
+							levels: {
+								"minecraft:thorns": 3
+							}
+						}
+					}
 					count: 1
 					id: "minecraft:enchanted_book"
 				}
@@ -117,6 +135,16 @@
 			rewards: [{
 				id: "0000000000000055"
 				item: {
+					components: {
+						"minecraft:enchantments": {
+							levels: {
+								"minecraft:mending": 1
+								"minecraft:protection": 4
+								"minecraft:unbreaking": 4
+							}
+						}
+						"minecraft:repair_cost": 1
+					}
 					count: 1
 					id: "powder_power:armor_quadrilium_leggings"
 				}
@@ -157,6 +185,13 @@
 			rewards: [{
 				id: "000000000000064F"
 				item: {
+					components: {
+						"minecraft:stored_enchantments": {
+							levels: {
+								"minecraft:silk_touch": 1
+							}
+						}
+					}
 					count: 1
 					id: "minecraft:enchanted_book"
 				}
@@ -178,6 +213,19 @@
 				{
 					id: "0000000000000060"
 					item: {
+						components: {
+							"minecraft:custom_name": "\"Orcrist\""
+							"minecraft:enchantments": {
+								levels: {
+									"minecraft:knockback": 2
+									"minecraft:looting": 3
+									"minecraft:mending": 1
+									"minecraft:sharpness": 5
+									"minecraft:sweeping_edge": 3
+								}
+							}
+							"minecraft:repair_cost": 15
+						}
 						count: 1
 						id: "powder_power:sword_quadrilium"
 					}
@@ -228,6 +276,13 @@
 			rewards: [{
 				id: "000000000000023C"
 				item: {
+					components: {
+						"minecraft:stored_enchantments": {
+							levels: {
+								"minecraft:blast_protection": 4
+							}
+						}
+					}
 					count: 1
 					id: "minecraft:enchanted_book"
 				}
@@ -330,6 +385,13 @@
 			rewards: [{
 				id: "000000000000056C"
 				item: {
+					components: {
+						"minecraft:stored_enchantments": {
+							levels: {
+								"minecraft:looting": 2
+							}
+						}
+					}
 					count: 1
 					id: "minecraft:enchanted_book"
 				}
@@ -398,6 +460,13 @@
 			rewards: [{
 				id: "0000000000000221"
 				item: {
+					components: {
+						"minecraft:stored_enchantments": {
+							levels: {
+								"minecraft:fortune": 3
+							}
+						}
+					}
 					count: 1
 					id: "minecraft:enchanted_book"
 				}
@@ -418,6 +487,17 @@
 			rewards: [{
 				id: "000000000000023B"
 				item: {
+					components: {
+						"minecraft:enchantments": {
+							levels: {
+								"minecraft:depth_strider": 2
+								"minecraft:feather_falling": 5
+								"minecraft:mending": 1
+								"minecraft:protection": 4
+								"minecraft:unbreaking": 4
+							}
+						}
+					}
 					count: 1
 					id: "powder_power:armor_quadrilium_boots"
 				}
@@ -478,11 +558,8 @@
 			rewards: [{
 				id: "000000000000046D"
 				item: {
-					components: {
-						"ftbquests:missing_item": "createaddition:creative_energy"
-					}
 					count: 1
-					id: "ftbquests:missing_item"
+					id: "createaddition:creative_energy"
 				}
 				type: "item"
 			}]

--- a/minecraft/config/ftbquests/quests/chapters/storage.snbt
+++ b/minecraft/config/ftbquests/quests/chapters/storage.snbt
@@ -493,6 +493,30 @@
 				{
 					id: "0506D21B80C4A377"
 					item: {
+						components: {
+							"sophisticatedbackpacks:columns_taken": 2
+							"sophisticatedcore:number_of_inventory_slots": 81
+							"sophisticatedcore:number_of_upgrade_slots": 3
+							"sophisticatedcore:render_info_tag": {
+								battery: {
+									chargeRatio: 1.0f
+								}
+								upgradeItems: [
+									{
+										count: 1
+										id: "sophisticatedbackpacks:battery_upgrade"
+									}
+									{ }
+									{ }
+								]
+							}
+							"sophisticatedcore:storage_uuid": [I;
+								1350220197
+								1918914004
+								-1772737088
+								-2103618607
+							]
+						}
 						count: 1
 						id: "sophisticatedbackpacks:gold_backpack"
 					}
@@ -716,11 +740,8 @@
 				count: 2
 				id: "50D1B5D465D65320"
 				item: {
-					components: {
-						"ftbquests:missing_item": "createaddition:modular_accumulator"
-					}
 					count: 1
-					id: "ftbquests:missing_item"
+					id: "createaddition:modular_accumulator"
 				}
 				type: "item"
 			}]
@@ -978,6 +999,9 @@
 			shape: "diamond"
 			size: 1.5d
 			tasks: [{
+				icon: {
+					id: "ae2:mysterious_cube"
+				}
 				id: "4A70D9D36AAE4D91"
 				structure: "ae2:meteorite"
 				type: "structure"

--- a/minecraft/config/ftbquests/quests/chapters/storage.snbt
+++ b/minecraft/config/ftbquests/quests/chapters/storage.snbt
@@ -20,7 +20,7 @@
 			}]
 			tasks: [{
 				id: "140F8526F4532B59"
-				item: { components: { "ftbquests:missing_item": "toms_storage:ts.inventory_connector" }, count: 1, id: "ftbquests:missing_item" }
+				item: { count: 1, id: "toms_storage:inventory_connector" }
 				type: "item"
 			}]
 			x: -2.5d
@@ -78,7 +78,7 @@
 			}]
 			tasks: [{
 				id: "31722823CCD5E4EF"
-				item: { components: { "ftbquests:missing_item": "toms_storage:ts.wireless_terminal" }, count: 1, id: "ftbquests:missing_item" }
+				item: { count: 1, id: "toms_storage:wireless_terminal" }
 				type: "item"
 			}]
 			x: -6.0d
@@ -97,7 +97,7 @@
 			}]
 			tasks: [{
 				id: "2E7F23E0BC4C2792"
-				item: { components: { "ftbquests:missing_item": "toms_storage:ts.adv_wireless_terminal" }, count: 1, id: "ftbquests:missing_item" }
+				item: { count: 1, id: "toms_storage:adv_wireless_terminal" }
 				type: "item"
 			}]
 			x: -6.0d
@@ -109,18 +109,15 @@
 			rewards: [{
 				id: "03290C09332099FD"
 				item: {
-					components: {
-						"ftbquests:missing_item": "toms_storage:ts.inventory_cable_framed"
-					}
 					count: 1
-					id: "ftbquests:missing_item"
+					id: "toms_storage:inventory_cable_framed"
 				}
 				type: "item"
 			}]
 			tasks: [{
 				count: 6L
 				id: "41D8672F7F12A79C"
-				item: { components: { "ftbquests:missing_item": "toms_storage:ts.inventory_cable" }, count: 1, id: "ftbquests:missing_item" }
+				item: { count: 1, id: "toms_storage:inventory_cable" }
 				type: "item"
 			}]
 			x: -4.5d
@@ -132,17 +129,14 @@
 			rewards: [{
 				id: "0FECAAA678334F39"
 				item: {
-					components: {
-						"ftbquests:missing_item": "toms_storage:ts.inventory_cable_connector_framed"
-					}
 					count: 1
-					id: "ftbquests:missing_item"
+					id: "toms_storage:inventory_cable_connector_framed"
 				}
 				type: "item"
 			}]
 			tasks: [{
 				id: "52DB6C060601CA15"
-				item: { components: { "ftbquests:missing_item": "toms_storage:ts.inventory_cable_connector" }, count: 1, id: "ftbquests:missing_item" }
+				item: { count: 1, id: "toms_storage:inventory_cable_connector" }
 				type: "item"
 			}]
 			x: -4.5d
@@ -161,7 +155,7 @@
 			}]
 			tasks: [{
 				id: "47357EE4D508C0C8"
-				item: { components: { "ftbquests:missing_item": "toms_storage:ts.inventory_hopper_basic" }, count: 1, id: "ftbquests:missing_item" }
+				item: { count: 1, id: "toms_storage:basic_inventory_hopper" }
 				type: "item"
 			}]
 			x: -4.5d

--- a/minecraft/config/ftbquests/quests/chapters/tips_and_tricks.snbt
+++ b/minecraft/config/ftbquests/quests/chapters/tips_and_tricks.snbt
@@ -3,6 +3,12 @@
 	default_quest_shape: ""
 	filename: "tips_and_tricks"
 	group: ""
+	icon: {
+		components: {
+			"ftbquests:icon": "ftbfiltersystem:textures/gui/sprites/info.png"
+		}
+		id: "ftbquests:custom_icon"
+	}
 	id: "394307726599DAF0"
 	order_index: 1
 	quest_links: [ ]

--- a/minecraft/config/ftbquests/quests/chapters/world_hopping.snbt
+++ b/minecraft/config/ftbquests/quests/chapters/world_hopping.snbt
@@ -4,6 +4,9 @@
 	filename: "world_hopping"
 	group: ""
 	icon: {
+		components: {
+			"ftbquests:icon": "minecraft:block/nether_portal"
+		}
 		id: "ftbquests:custom_icon"
 	}
 	id: "5C3449C5F42C2A48"
@@ -23,6 +26,12 @@
 			}]
 			tasks: [{
 				dimension: "minecraft:the_end"
+				icon: {
+					components: {
+						"ftbquests:icon": "minecraft:textures/entity/end_portal.png"
+					}
+					id: "ftbquests:custom_icon"
+				}
 				id: "7E969B91EB428FB5"
 				type: "dimension"
 			}]
@@ -124,6 +133,9 @@
 				type: "item"
 			}]
 			tasks: [{
+				icon: {
+					id: "minecraft:stone_bricks"
+				}
 				id: "3403FDACF06DC43B"
 				structure: "betterstrongholds:stronghold"
 				type: "structure"

--- a/minecraft/config/ftbquests/quests/lang/en_us.snbt
+++ b/minecraft/config/ftbquests/quests/lang/en_us.snbt
@@ -76,7 +76,7 @@
 	quest.00000000000000C7.quest_desc: [
 		"Cobblestone can be much more useful than dirt."
 		""
-		"Gather 64 Cobblestone and we'll give ya your first bridge made from... well, cobblestone!"
+		"Gather 16 Cobblestone and we'll give ya your first bridge made from... well, cobblestone!"
 	]
 	quest.00000000000004FB.title: "Armor Blueprints"
 	quest.0000000000000522.quest_desc: ["This is your basic all in one tool."]
@@ -189,7 +189,7 @@
 	quest.0D77CE91690DFD0F.quest_desc: ["After placing the Train Station, open the GUI to Assemble a train. Place this block on the blue highlight on the tracks and voila, you have started building your first train!"]
 	quest.0D77CE91690DFD0F.quest_subtitle: "Every train needs one"
 	quest.0DED09C3096C985D.quest_desc: ["Place a Pure Daisy next to a Blaze Mesh and you get Obsidian, but be careful where you place it because you might not be able to move it once it transforms. Think: Nether Portal"]
-	quest.0E4D24AAB4F4DC58.quest_desc: ["Check to get The One Probe Read Me"]
+	quest.0E4D24AAB4F4DC58.quest_desc: ["Check to get The One Probe Read Me, which is used to configure TOP HUD."]
 	quest.0E4D24AAB4F4DC58.title: "The One Probe Read Me"
 	quest.0E9F95234AB4F307.quest_desc: ["The Ritual of Gaia is a trial often undertaken by elves. It yields Gaia Spirits, which are coveted as fragments of the power of the Goddess of Gaia herself.This ritual requires an Active Beacon with Gaia Pylons surrounding it (functioning as an altar), as well as a single Terrasteel Ingot (as a sacrifice)."]
 	quest.0F212D61E278C98E.title: "Apprentice Witch Hunter"
@@ -249,7 +249,7 @@
 	quest.2613E24F95C84B21.quest_subtitle: "You're Fired!"
 	quest.285AF2D75FD9809C.quest_desc: ["This jetpack has some limitations. First, it cannot fly over the void. Second, the landings can be hard, and you might take damage!"]
 	quest.28D15A9B43C825CE.quest_desc: ["The Rope Pulley allows you to make easy-to-craft early game elevators."]
-	quest.29B69483965D4F12.quest_desc: ["Craft a stack of torches and get a handy dandy Torch Sling!"]
+	quest.29B69483965D4F12.quest_desc: ["Craft some torches and get a handy dandy Torch Sling!"]
 	quest.2AA453BF3617F5BF.quest_desc: ["Gantry Carriages can mount to and slide along a Gantry Shaft."]
 	quest.2AC4427434E9FBCB.quest_desc: ["Right-click with this rod will place Dirt for some mana cost."]
 	quest.2B13CF9D2DB9872C.quest_desc: ["When worn, it is able to store Mana like the Mana Tablet. "]

--- a/minecraft/defaultconfigs/create-stuff-additions.toml
+++ b/minecraft/defaultconfigs/create-stuff-additions.toml
@@ -1,0 +1,32 @@
+["Jetpack Height Restriction"]
+	brassJetpackMaxHeight = 28.0
+	andesiteJetpackMaxHeight = 18.0
+	copperJetpackMaxHeight = 18.0
+	netheriteJetpackMaxHeight = 28.0
+	enableAboveCloudEnchant = true
+
+["Jetpack/Grapplin Speed"]
+	brassJetpackSpeed = 0.06
+	andesiteJetpackSpeed = 0.08
+	copperJetpackSpeed = 0.02
+	netheriteJetpackSpeed = 0.08
+	grapplinWhiskSpeed = 0.2
+
+["Fuel/Water Capacity"]
+	gadgetCapacity = 1600.0
+	smallTankCapacity = 800.0
+	mediumTankCapacity = 1600.0
+	largeTankCapacity = 3200.0
+
+[Enchantments]
+	enableDiggingEnchant = true
+	enableImpactEnchant = true
+	enableGravityGunEnchant = true
+	enableHellfireEnchant = true
+
+["Drone Module"]
+	enableDrillDroneModule = true
+	enableFanDroneModule = true
+	enableMagnetDroneModule = true
+	enableVaultDroneModule = true
+	MagnetModuleBlockLimitation = false


### PR DESCRIPTION
Fixes most of the broken enchantments on items, items that despite having the same ID register as a missing item and ones specific case where the biomass item existed and was craftable but could not be found in the creative menu or JEI
### fixes:
- [x] the whole create section
- [x] the whole hunter section
### tweaks:
- [x] added appropriate icons to icon-less quests
- [x] slightly moved some quests (the jetpacks mainly)
- [x] added a config that was being relied on to use the "above the clouds" jetpack enchant
- [x] moved the jetpack enchant to the nether jetpack reward

